### PR TITLE
Adding default usage of custom file name

### DIFF
--- a/lib/generate-screenshot-file-path.js
+++ b/lib/generate-screenshot-file-path.js
@@ -15,8 +15,7 @@ const kebabCase = require('lodash/kebabCase'),
  * @param {Object} nightwatchClient Instance of the current nightwatch API interface
  * @param {String} basePath A custom string that can be specified to further distinguish
  * the location where the screenshot will be stored or read from.
- * @param {String} fileName The custom filename that was passed on assertion; defaults
- * to selectorId.
+ * @param {String} [fileName] A custom filename for the screenshot
  */
 function defaultScreenshotFilePath(nightwatchClient, basePath, fileName) {
     const moduleName = nightwatchClient.currentTest.module,
@@ -34,8 +33,7 @@ function defaultScreenshotFilePath(nightwatchClient, basePath, fileName) {
  * @param {Object} nightwatchClient Instance of the current nightwatch API interface
  * @param {String} basePath A custom string that can be specified to further distinguish
  * the location where the screenshot will be stored or read from.
- * @param {String} fileName The custom filename that was passed on assertion; defaults
- * to selectorId.
+ * @param {String} [fileName] A custom filename for the screenshot
  */
 module.exports = function generateScreenshotFilePath(nightwatchClient, basePath, fileName) {
     const globalSettings = get(

--- a/lib/generate-screenshot-file-path.js
+++ b/lib/generate-screenshot-file-path.js
@@ -15,13 +15,16 @@ const kebabCase = require('lodash/kebabCase'),
  * @param {Object} nightwatchClient Instance of the current nightwatch API interface
  * @param {String} basePath A custom string that can be specified to further distinguish
  * the location where the screenshot will be stored or read from.
+ * @param {String} fileName The custom filename that was passed on assertion; defaults
+ * to selectorId.
  */
-function defaultScreenshotFilePath(nightwatchClient, basePath) {
+function defaultScreenshotFilePath(nightwatchClient, basePath, fileName) {
     const moduleName = nightwatchClient.currentTest.module,
         testName = nightwatchClient.currentTest.name,
-        kebabName = `${kebabCase(testName)}.png`
+        kebabName = `${kebabCase(testName)}.png`,
+        screenShotName = fileName ? `${fileName}.png` : kebabName
 
-    return path.join(process.cwd(), basePath, moduleName, kebabName)
+    return path.join(process.cwd(), basePath, moduleName, screenShotName)
 }
 
 /**
@@ -45,5 +48,5 @@ module.exports = function generateScreenshotFilePath(nightwatchClient, basePath,
         return globalSettings.generate_screenshot_path(nightwatchClient, basePath, fileName)
     }
 
-    return defaultScreenshotFilePath(nightwatchClient, basePath)
+    return defaultScreenshotFilePath(nightwatchClient, basePath, fileName)
 }

--- a/tests/lib/generate-screenshot-file-path-test.js
+++ b/tests/lib/generate-screenshot-file-path-test.js
@@ -16,4 +16,9 @@ describe('generateScreenshotFilePath', () => {
         expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline'))
             .toEqual(`${process.cwd()}/baseline/visualizations/bar-plots.png`)
     })
+
+    it('should generate a file path by using the basePath parameter, and a custom filename', () => {
+        expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline', 'foo-test'))
+            .toEqual(`${process.cwd()}/baseline/visualizations/foo-test.png`)
+    })
 })


### PR DESCRIPTION
The custom filename was only being used if a custom 'generate_screenshot_path' function was defined.