### PR TITLE
Moving custom filename addition into the proper module

### DIFF
--- a/lib/compare-with-baseline.js
+++ b/lib/compare-with-baseline.js
@@ -39,17 +39,17 @@ module.exports = function compareWithBaseline(
         completeLatestPath = generateScreenshotFilePath(
             nightwatchClient,
             latest_screenshots_path,
-            `${fileName}${latest_suffix}.png`
+            `${fileName}${latest_suffix}`
         ),
         completeBaselinePath = generateScreenshotFilePath(
             nightwatchClient,
             baseline_screenshots_path,
-            `${fileName}${baseline_suffix}.png`
+            `${fileName}${baseline_suffix}`
         ),
         completeDiffPath = generateScreenshotFilePath(
             nightwatchClient,
             diff_screenshots_path,
-            `${fileName}${diff_suffix}.png`
+            `${fileName}${diff_suffix}`
         )
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Addition of the extension to the custom file name is being done in generate-screenshot-file-path.