### PR TITLE
Moving custom filename extension append into generate filename module

### DIFF
--- a/lib/compare-with-baseline.js
+++ b/lib/compare-with-baseline.js
@@ -39,17 +39,17 @@ module.exports = function compareWithBaseline(
         completeLatestPath = generateScreenshotFilePath(
             nightwatchClient,
             latest_screenshots_path,
-            `${fileName}${latest_suffix}.png`
+            `${fileName}${latest_suffix}`
         ),
         completeBaselinePath = generateScreenshotFilePath(
             nightwatchClient,
             baseline_screenshots_path,
-            `${fileName}${baseline_suffix}.png`
+            `${fileName}${baseline_suffix}`
         ),
         completeDiffPath = generateScreenshotFilePath(
             nightwatchClient,
             diff_screenshots_path,
-            `${fileName}${diff_suffix}.png`
+            `${fileName}${diff_suffix}`
         )
 
     return new Promise((resolve, reject) => {

--- a/lib/generate-screenshot-file-path.js
+++ b/lib/generate-screenshot-file-path.js
@@ -4,6 +4,11 @@ const kebabCase = require('lodash/kebabCase'),
     path = require('path'),
     get = require('lodash/get')
 
+
+function appendExtensionToFilename(fileName) {
+    return fileName ? `${fileName}.png` : undefined
+}
+
 /**
  * The default screenshot file path generator based on the following information
  * extracted from the nightwatch public interface:
@@ -20,8 +25,8 @@ const kebabCase = require('lodash/kebabCase'),
 function defaultScreenshotFilePath(nightwatchClient, basePath, fileName) {
     const moduleName = nightwatchClient.currentTest.module,
         testName = nightwatchClient.currentTest.name,
-        kebabName = `${kebabCase(testName)}.png`,
-        screenShotName = fileName ? `${fileName}.png` : kebabName
+        kebabName = `${kebabCase(testName)}`,
+        screenShotName = appendExtensionToFilename(fileName || kebabName)
 
     return path.join(process.cwd(), basePath, moduleName, screenShotName)
 }
@@ -43,7 +48,8 @@ module.exports = function generateScreenshotFilePath(nightwatchClient, basePath,
     )
 
     if (globalSettings && globalSettings.generate_screenshot_path) {
-        return globalSettings.generate_screenshot_path(nightwatchClient, basePath, fileName)
+        return globalSettings.generate_screenshot_path(
+            nightwatchClient, basePath, appendExtensionToFilename(fileName))
     }
 
     return defaultScreenshotFilePath(nightwatchClient, basePath, fileName)

--- a/tests/lib/generate-screenshot-file-path-test.js
+++ b/tests/lib/generate-screenshot-file-path-test.js
@@ -1,13 +1,23 @@
 'use strict'
 
 const generateScreenshotFilePath = require('../../lib/generate-screenshot-file-path')
+const path = require('path')
 
 describe('generateScreenshotFilePath', () => {
+    let customNameFn
+
     function getNightwatchClient() {
         return {
             currentTest: {
                 module: 'visualizations',
                 name: 'barPlots'
+            },
+            globals: {
+                test_settings: {
+                    visual_regression_settings: {
+                        generate_screenshot_path: customNameFn
+                    }
+                }
             }
         }
     }
@@ -20,5 +30,13 @@ describe('generateScreenshotFilePath', () => {
     it('should generate a file path by using the basePath parameter, and a custom filename', () => {
         expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline', 'foo-test'))
             .toEqual(`${process.cwd()}/baseline/visualizations/foo-test.png`)
+    })
+
+    it('should pass the correct filename to the custom naming function', () => {
+        customNameFn = (client, basePath, fileName) =>
+            path.join(process.cwd(), basePath, client.currentTest.module, `custom-${fileName}`)
+
+        expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline', 'foo-test'))
+            .toEqual(`${process.cwd()}/baseline/visualizations/custom-foo-test.png`)
     })
 })


### PR DESCRIPTION
Appending the extension to the custom filename in a single place to affect both default and custom file names.