### PR TITLE
fix(compare-with-baseline): reverse deletion of promptScreenshotOverr…

### DIFF
--- a/lib/compare-with-baseline.js
+++ b/lib/compare-with-baseline.js
@@ -70,7 +70,7 @@ module.exports = function compareWithBaseline(
                         completeDiffPath,
                         diff.image
                     ), resolve)
-                    .then(() =>     (
+                    .then(() => promptScreenshotOverride(
                         completeLatestPath,
                         completeBaselinePath,
                         completeDiffPath


### PR DESCRIPTION
reverse deletion of promptScreenshotOverride call to enable the prompt

I think this was deleted by error