### PR TITLE
Fix for screens with a higher than 1 pixel ratio

### DIFF
--- a/commands/captureElementScreenshot.js
+++ b/commands/captureElementScreenshot.js
@@ -35,6 +35,19 @@ CaptureElementScreenshot.prototype.command = function command(
         const { x, y } = location
         let { width, height } = size
 
+        /*
+         * Here we get the pixel density of the window and 
+         * ensure that we adjust the width and height accordingly
+         */
+        api.execute(function () {
+          return window.devicePixelRatio
+        }, [], function (devicePixelRatio) {
+          if (devicePixelRatio.value > 1) {
+            width *= devicePixelRatio.value
+            height *= devicePixelRatio.value
+          }
+        });
+
         if (width === 0 || height === 0) {
             this.client.assertion(
                 false,

--- a/commands/captureElementScreenshot.js
+++ b/commands/captureElementScreenshot.js
@@ -32,7 +32,7 @@ CaptureElementScreenshot.prototype.command = function command(
         promisifyCommand(api, 'getElementSize', [selector]),
         promisifyCommand(api, 'screenshot', [false])
     ]).then(([location, size, screenshotEncoded]) => {
-        const { x, y } = location
+        let { x, y } = location
         let { width, height } = size
 
         /*
@@ -43,6 +43,8 @@ CaptureElementScreenshot.prototype.command = function command(
           return window.devicePixelRatio
         }, [], function (devicePixelRatio) {
           if (devicePixelRatio.value > 1) {
+            x *= devicePixelRatio.value
+            y *= devicePixelRatio.value
             width *= devicePixelRatio.value
             height *= devicePixelRatio.value
           }

--- a/commands/captureElementScreenshot.js
+++ b/commands/captureElementScreenshot.js
@@ -40,14 +40,12 @@ CaptureElementScreenshot.prototype.command = function command(
          * ensure that we adjust the width and height accordingly
          */
         api.execute(function () {
-          return window.devicePixelRatio
+            return window.devicePixelRatio
         }, [], function (devicePixelRatio) {
-          if (devicePixelRatio.value > 1) {
             x *= devicePixelRatio.value
             y *= devicePixelRatio.value
             width *= devicePixelRatio.value
             height *= devicePixelRatio.value
-          }
         });
 
         if (width === 0 || height === 0) {


### PR DESCRIPTION
Added check that if the device has a greater than 1 devicePixelRatio, then we update the width and height to these values. This allows displays with a denser pixel ratio to crop and resize without any issues.