### PR TITLE
Generate filepath with the browser name and OS

### DIFF
--- a/lib/generate-screenshot-file-path.js
+++ b/lib/generate-screenshot-file-path.js
@@ -25,10 +25,11 @@ function appendExtensionToFilename(fileName) {
 function defaultScreenshotFilePath(nightwatchClient, basePath, fileName) {
     const moduleName = nightwatchClient.currentTest.module,
         testName = nightwatchClient.currentTest.name,
+        browserName = nightwatchClient.capabilities.browserName + '_' + nightwatchClient.capabilities.platform,
         kebabName = `${kebabCase(testName)}`,
         screenShotName = appendExtensionToFilename(fileName || kebabName)
 
-    return path.join(process.cwd(), basePath, moduleName, screenShotName)
+    return path.join(process.cwd(), basePath, browserName, moduleName, screenShotName)
 }
 
 /**


### PR DESCRIPTION
With this change, you will then be able to test cross browsers without them interfering with each other.