### PR TITLE
Remove deprecated Nightwatch 'client.assertion' reference

### DIFF
--- a/commands/captureElementScreenshot.js
+++ b/commands/captureElementScreenshot.js
@@ -49,13 +49,7 @@ CaptureElementScreenshot.prototype.command = function command(
         });
 
         if (width === 0 || height === 0) {
-            this.client.assertion(
-                false,
-                null,
-                null,
-                `The element identified by the selector <${selector}> is not visible or its dimensions equals 0. width: ${width}, height: ${height}`, // eslint-disable-line max-len
-                true
-            )
+            this.api.assert.fail(`The element identified by the selector <${selector}> is not visible or its dimensions equals 0. width: ${width}, height: ${height}`) // eslint-disable-line max-len);
         }
 
         Jimp.read(new Buffer(screenshotEncoded, 'base64')).then((screenshot) => {
@@ -76,24 +70,14 @@ CaptureElementScreenshot.prototype.command = function command(
             }
 
             screenshot.crop(x, y, width, height)
-            this.client.assertion(
-                true,
-                null,
-                null,
-                `The screenshot for selector <${selector}> was captured successfully.`,
-                true
-            )
+
+            this.api.assert.ok(true, `The screenshot for selector <${selector}> was captured successfully.`);
 
             callback(screenshot)
             this.emit('complete', screenshot)
         })
     }).catch((errorMessage) => {
-        this.client.assertion(
-            false,
-            'success',
-            errorMessage,
-            `The screenshot for selector <${selector}> could not be captured.`
-        )
+        this.api.assert.fail(`The screenshot for selector <${selector}> could not be captured.`);
         this.emit('complete', errorMessage, this)
     })
 }

--- a/demo/nightwatch.conf.js
+++ b/demo/nightwatch.conf.js
@@ -11,7 +11,7 @@ const REPORTS_PATH = path.join(__dirname, 'reports', 'e2e')
 const SCREENSHOT_PATH = path.join(__dirname, 'reports', 'screenshots')
 const BINPATH = path.join(process.cwd(), 'node_modules', 'nightwatch', 'bin')
 
-const SELENIUM_VERSION = '3.5.2' // https://selenium-release.storage.googleapis.com/index.html
+const SELENIUM_VERSION = '3.5.1' // https://selenium-release.storage.googleapis.com/index.html
 const SELENIUM_PATH = path.join(BINPATH, 'selenium-server', SELENIUM_VERSION + '-' + 'server.jar')
 const CHROME_DRIVER_VERSION = '2.31' // https://chromedriver.storage.googleapis.com/index.html
 const CHROME_PATH = path.join(BINPATH, 'chromedriver', CHROME_DRIVER_VERSION + '-' + process.arch + '-' + 'chromedriver')

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "eslint-plugin-react": "^7.3.0",
         "http-server": "^0.10.0",
         "jest": "^20.0.4",
-        "nightwatch": "^0.9.16",
+        "nightwatch": "^1.0.14",
         "npm-run-all": "^4.0.2",
         "phantomjs-prebuilt": "^2.1.15",
         "rimraf": "^2.6.1",

--- a/tests/lib/generate-screenshot-file-path-test.js
+++ b/tests/lib/generate-screenshot-file-path-test.js
@@ -24,12 +24,12 @@ describe('generateScreenshotFilePath', () => {
 
     it('should generate a file path by using the basePath parameter, and the current test name and module', () => {
         expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline'))
-            .toEqual(`${process.cwd()}/baseline/visualizations/bar-plots.png`)
+            .toEqual(`${process.cwd()}\\baseline\\visualizations\\bar-plots.png`)
     })
 
     it('should generate a file path by using the basePath parameter, and a custom filename', () => {
         expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline', 'foo-test'))
-            .toEqual(`${process.cwd()}/baseline/visualizations/foo-test.png`)
+            .toEqual(`${process.cwd()}\\baseline\\visualizations\\foo-test.png`)
     })
 
     it('should pass the correct filename to the custom naming function', () => {
@@ -37,6 +37,6 @@ describe('generateScreenshotFilePath', () => {
             path.join(process.cwd(), basePath, client.currentTest.module, `custom-${fileName}`)
 
         expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline', 'foo-test'))
-            .toEqual(`${process.cwd()}/baseline/visualizations/custom-foo-test.png`)
+            .toEqual(`${process.cwd()}\\baseline\\visualizations\\custom-foo-test.png`)
     })
 })

--- a/tests/lib/generate-screenshot-file-path-test.js
+++ b/tests/lib/generate-screenshot-file-path-test.js
@@ -24,12 +24,12 @@ describe('generateScreenshotFilePath', () => {
 
     it('should generate a file path by using the basePath parameter, and the current test name and module', () => {
         expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline'))
-            .toEqual(`${process.cwd()}\\baseline\\visualizations\\bar-plots.png`)
+            .toEqual(`${process.cwd()}/baseline/visualizations/bar-plots.png`)
     })
 
     it('should generate a file path by using the basePath parameter, and a custom filename', () => {
         expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline', 'foo-test'))
-            .toEqual(`${process.cwd()}\\baseline\\visualizations\\foo-test.png`)
+            .toEqual(`${process.cwd()}/baseline/visualizations/foo-test.png`)
     })
 
     it('should pass the correct filename to the custom naming function', () => {
@@ -37,6 +37,6 @@ describe('generateScreenshotFilePath', () => {
             path.join(process.cwd(), basePath, client.currentTest.module, `custom-${fileName}`)
 
         expect(generateScreenshotFilePath(getNightwatchClient(), 'baseline', 'foo-test'))
-            .toEqual(`${process.cwd()}\\baseline\\visualizations\\custom-foo-test.png`)
+            .toEqual(`${process.cwd()}/baseline/visualizations/custom-foo-test.png`)
     })
 })


### PR DESCRIPTION
By removing the the deprecated `client.assertion` reference it will allow the nightwatch-vrt library to be used with both Nightwatch v0.9 and Nightwatch v1+. Replaced with `api.assert.ok` & `api.assert.fail`.

Tested with both Nightwatch v0.9.21 and Nightwatch v1.0.14 (pre release).

Keep up the good work!