### PR TITLE
Fix silent fail when error in image processing

### DIFF
--- a/assertions/screenshotIdenticalToBaseline.js
+++ b/assertions/screenshotIdenticalToBaseline.js
@@ -53,7 +53,10 @@ exports.assertion = function screenshotIdenticalToBaseline(
                 compareWithBaseline(this.api, screenshot, fileName, settings).then((result) => {
                     comparisonResult = result
                     done()
-                })
+                }, (reject) => {
+                    comparisonResult = reject
+                    done()
+                });
             })
             .perform((done) => {
                 callback(comparisonResult)


### PR DESCRIPTION
Fixes problem with NWJS parallel run and when there is any error in jimp or fs. Before this error there is no error thrown and the whole testSuite would just fail silently. With this fix the assert fails with error message like:
`   - Verify Screenshoot #3 (3.322s)
   Visual regression test results for element <.DashboardLayout_topBar .AppHeaderLayout_navigation>.  - expected "true" but got: "Error: Invalid file signature"
       at Object.screenshotIdenticalToBaseline [as Verify Screenshoot #3] (###\e2e\tests\BVT-Dataload/PG-DEBUG-000.js:43:8)
       at process._tickCallback (internal/process/next_tick.js:176:11)`
This problem could occur quite easily as it is a good idea to store image files as git-lfs. But when LFS fails for any reason like server update etc. All tests would just start to fail silently because instead of the images there would be LFS placeholders.